### PR TITLE
CCLE-5758 - Embed display option for Google Drive resource should use embed code

### DIFF
--- a/repository/googledocs/lib.php
+++ b/repository/googledocs/lib.php
@@ -485,12 +485,11 @@ class repository_googledocs extends repository {
             die;
         } else {
             $file = $this->service->files->get($id);
-            $type = str_replace('application/vnd.google-apps.', '', $file['mimeType']);
-            if (in_array($type, self::$GOOGLE_LIVE_DOCS_TYPES)) {
+            if ($file->editable) {
+                // If resource is editable, then display using editor link.
                 redirect($file->alternateLink);
             } else {
-                header("Location: " . $file->webContentLink);
-                die;
+                redirect($file->embedLink);
             }
         }
     }


### PR DESCRIPTION
- If user has editing rights, then see an editor, else user will see embedded/readonly link.
